### PR TITLE
Stage Neverforum to official website

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,9 @@ include("includes/header.php");
 
 		<h2>News</h2>
 		
+		<h3>2017-01-24: Neverforum reopened</h3>
+		<p>After nearly 12 months of downtime, <a href="http://neverforum.com/">Neverforum</a> has been reopened.</p>
+		
 		<h3>2016-02-07: Nevercorner.net closing</h3>
 		<p><a href="http://nevercorner.net">Nevercorner.net</a>, the site that generously hosted the Neverforum, the Nevertable and the Neverwiki for over ten years, has shut down today. An effort is underway to provide a new place of discussion for the Neverball community.</p>
 		<p>In the mean time, see you on Reddit, Steam or Github (links below).</p>
@@ -28,7 +31,8 @@ include("includes/header.php");
 		<p>Neverball is known to run under Linux, Windows, FreeBSD, and Mac OSX. Hardware accelerated OpenGL is required. A modern processor is recommended.</p>
 
 		<h2>Community &amp; Contact</h2>
-		<p><a href="https://www.reddit.com/r/neverball">/r/neverball on Reddit</a>, <a href="https://steamcommunity.com/groups/neverball">Neverball Steam group</a>, <a href="https://github.com/Neverball">Github</a>.</p>
+		<p>Visit the <a href="http://neverforum.com/">Neverforum</a> to get in touch with other players and contributors.</p>
+		<p>We are also on <a href="https://www.reddit.com/r/neverball">Reddit</a>, <a href="https://github.com/Neverball">Github</a>, and <a href="https://steamcommunity.com/groups/neverball">Steam</a>.</p>
 
 		<h2>Level Design</h2>
 		<p>Players interested in trying their hand at level creation are encouraged to read through the <a href="http://github.com/neverball/neverball-docs" onClick="javascript: pageTracker._trackPageview('/outgoing/documentation');">level design documentation</a>. Levels of sufficent quality may be included in the next version; authors will be credited in-game.</p>


### PR DESCRIPTION
Figured I would take initiative, and get this started. There are a couple questions I would like to ask before finalizing this set of changes.

1. Should we reuse the old Neverforum handle for JavaScript tracking?
2. Which of the auxiliary links should we keep on the website?