### PR TITLE
caffeinatedcontent going offline, serve from icculus

### DIFF
--- a/includes/getdownload.php
+++ b/includes/getdownload.php
@@ -5,19 +5,27 @@ if(($dlSuffix == ".tar.gz" || $dlSuffix == ".zip" || $dlSuffix == "-setup.exe" |
 	// parasti[2009-12-12]: connection timeouts cause warnings to
 	// spill all over the page, tweaked this to silence them.
 
-	$whichServer = time() % 2;
+	//$whichServer = time() % 2;
+	$whichServer = 0;
 	$server0 = @fsockopen("icculus.org", 80, $errno, $errstr, 10);
-	$server1 = @fsockopen("caffeinatedcontent.com", 80, $errno, $errstr, 10);
+
+//      CaffeinatedContent is going offline (for now, shutting down webhost, planned move to CDN) -- Jammnrose 4/11/18
+// 	$server1 = @fsockopen("caffeinatedcontent.com", 80, $errno, $errstr, 10);
+// 	if($server0 == false){
+// 		$whichServer = 1;
+// 		if($server1 == false){
+// 			$whichServer = 2;
+// 		}
+// 	}else if($server1 == false){
+// 		$whichServer = 0;
+// 	}
+	
 	if($server0 == false){
-		$whichServer = 1;
-		if($server1 == false){
-			$whichServer = 2;
-		}
-	}else if($server1 == false){
-		$whichServer = 0;
+		$whichServer = 2;
 	}
+
 	@fclose($server0);
-	@fclose($server1);
+// 	@fclose($server1);
 	switch($whichServer){
 	case 0:
 		header('Location: http://icculus.org/neverball/'.$_GET["fileName"]);


### PR DESCRIPTION
My webhost is charging me through the nose for stuff I don't need or want.

I'm transferring registrars for the caffeinatedcontent.com domain (already in progress :( I only saw that neverball files were still being served by my webhost by looking at a backup of access logs.)

In a week or two when the transfer goes through, I can open an account with a CDN such as https://bunnycdn.com and take all the traffic there for like USD$1.00/month and only use icculus as a backup, if that makes sense. I'm happy to continue to support Neverball and FOSS financially.

PS: I won't promise anything, but I do want to sink some time into a new Mac build. I'm thinking the best option is simple; a zip with Neverball + Neverputt, common files duplicated. This will eat some extra HD space, but oh well. At least both apps would be portable... and the HD space is nothing nowadays for 1-2 hundred meg of duplication... if that.