### PR TITLE
Add link to MacPorts for MacOS X

### DIFF
--- a/download.php
+++ b/download.php
@@ -25,7 +25,7 @@ include("includes/getdownload.php");
 			<dt>Microsoft Windows</dt>
 				<dd><p><a href="neverball-1.6.0.zip" title="Neverball for Microsoft Windows" onClick="javascript: pageTracker._trackPageview('/downloads/win-1.6.0');" id="win">neverball-1.6.0.zip</a> (73 MB)</p></dd>
 			<dt>Mac OS X (Universal Binary)</dt>
-				<dd><p><a href="neverball-1.5.3.dmg" title="Neverball for Mac OS X" onClick="javascript: pageTracker._trackPageview('/downloads/mac-1.5.3');" id="mac">neverball-1.5.3.dmg</a> (52.04 MB)<br>Neverball 1.6.0 is currently not available on Mac OS X. Give <a href="http://uppgarn.com/nuncabola/" title="Nuncabola" onClick="javascript: pageTracker._trackPageview('/downloads/nuncabola');">Nuncabola</a> a try!</p></dd>
+				<dd><p><a href="neverball-1.5.3.dmg" title="Neverball for Mac OS X" onClick="javascript: pageTracker._trackPageview('/downloads/mac-1.5.3');" id="mac">neverball-1.5.3.dmg</a> (52.04 MB)<br>Neverball 1.6.0 is <a href="https://ports.macports.org/port/neverball/">packaged by MacPorts</a>. Give <a href="http://uppgarn.com/nuncabola/" title="Nuncabola" onClick="javascript: pageTracker._trackPageview('/downloads/nuncabola');">Nuncabola</a> a try!</p></dd>
 		</dl>
 		<h2>Custom Levels</h2>
 		<p>If you are looking for additional content for either Neverball or Neverputt, be sure to visit the <a href="http://neverforum.com" onClick="javascript: pageTracker._trackPageview('/outgoing/neverforum');">Discussion Forum</a> to find custom levels as well as other content created by community members.</p>


### PR DESCRIPTION
MacPorts has a functional Neverball 1.6.0 and they even are distributing binaries.

As an aside, it is possible to get MacPorts to create a .pkg/.dmg of Neverball for stand-alone installation and you could potentially distribute those as your MacOS X builds.